### PR TITLE
Fix: 로그인 비밀번호 단방향 암호화로 수정(#4)

### DIFF
--- a/src/components/Accounts/Login.tsx
+++ b/src/components/Accounts/Login.tsx
@@ -39,11 +39,9 @@ const Login = () => {
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const passwordValue = password.value.toString();
-    const secretKey = process.env.REACT_APP_SECRET_KEY || 'default_secret_key';
 
-    const encryptedPassword = CryptoJS.AES.encrypt( passwordValue, secretKey).toString();
+    const encryptedPassword = CryptoJS.SHA256( passwordValue).toString();
     try {
-      console.log("요청")
       const res: LoginResponse = await api.post("/auth/login", {
         email: email.value,
         password: encryptedPassword,


### PR DESCRIPTION
## Issues
-  #4 

## description
- 로그인 비밀번호 양방향 -> 단방향

양방향으로 암호화 할 경우, 암호화 값이 시크릿 키에 의존해 랜덤으로 값이 부여됩니다. 백에서는 암호화된 비밀번호를 그대로 DB에 저장합니다. 이때 비밀번호 값은 같아도 암호화된 값이 랜덤이므로 일치하지 않는다는 문제가 있었습니다.
암호화된 값을 그대로 저장해서 확인여부를 따지기 때문에 프론트에서도 암호화를 단방향으로 알맞게 수정했습니다.